### PR TITLE
Add 10-bit support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ repository = "https://github.com/PistonDevelopers/y4m.git"
 documentation = "http://docs.piston.rs/y4m/y4m/"
 
 [dev-dependencies]
-resize = "0.0.1"
+resize = "0.3.0"

--- a/examples/resize.rs
+++ b/examples/resize.rs
@@ -20,6 +20,10 @@ fn main() {
     };
     let mut decoder = y4m::decode(&mut infh).unwrap();
 
+    if decoder.get_bit_depth() != 8 {
+        panic!("Unsupported bit depth {}, this example only supports 8.",
+            decoder.get_bit_depth());
+    }
     let (w1, h1) = (decoder.get_width(), decoder.get_height());
     let dst_dims: Vec<_> = args[2].split("x").map(|s| s.parse().unwrap()).collect();
     let (w2, h2) = (dst_dims[0], dst_dims[1]);

--- a/examples/resize.rs
+++ b/examples/resize.rs
@@ -4,6 +4,7 @@ extern crate resize;
 use std::io;
 use std::env;
 use std::fs::File;
+use resize::Pixel::Gray8;
 use resize::Type::Triangle;
 
 fn main() {
@@ -22,7 +23,7 @@ fn main() {
     let (w1, h1) = (decoder.get_width(), decoder.get_height());
     let dst_dims: Vec<_> = args[2].split("x").map(|s| s.parse().unwrap()).collect();
     let (w2, h2) = (dst_dims[0], dst_dims[1]);
-    let mut resizer = resize::new(w1, h1, w2, h2, Triangle);
+    let mut resizer = resize::new(w1, h1, w2, h2, Gray8, Triangle);
     let mut dst = vec![0;w2*h2];
 
     let mut outfh: Box<io::Write> = if args[3] == "-" {
@@ -38,7 +39,7 @@ fn main() {
     loop {
         match decoder.read_frame() {
             Ok(frame) => {
-                resizer.run(frame.get_y_plane(), &mut dst);
+                resizer.resize(frame.get_y_plane(), &mut dst);
                 let out_frame = y4m::Frame::new([&dst, &[], &[]], None);
                 if encoder.write_frame(&out_frame).is_err() { break }
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ pub enum Error {
     EOF,
     /// Bad input parameters provided.
     BadInput,
+    /// Unknown colorspace (possibly just unimplemented)
+    UnknownColorspace,
     /// Error while parsing the file/frame header.
     // TODO(Kagami): Better granularity of parse errors.
     ParseError,
@@ -209,7 +211,7 @@ impl<'d, R: Read> Decoder<'d, R> {
                         b"420jpeg" => Some(Colorspace::C420jpeg),
                         b"420paldv" => Some(Colorspace::C420paldv),
                         b"420mpeg2" => Some(Colorspace::C420mpeg2),
-                        _ => None,
+                        _ => return Err(Error::UnknownColorspace)
                     };
                 },
                 _ => {},


### PR DESCRIPTION
I did that mostly by adding a few helpers on `Colorspace`, to know both the bit depth and the bytes per sample, in order to decode and encode each sample as expected.  I didn’t add any support for 9, 12, 14 or 16 bit files, as I couldn’t find any in the wild.

The resize example has been modified to handle >8 colorspaces, although it may make sense to put part of that in the library’s API instead.

This PR also removes encoder support for unspecified colorspace, in general it’s better to be explicit about it but I’m fine with putting it back if that’s wanted.

Fixes #9.