### PR TITLE
Fix clippy warnings and fmt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,19 +427,19 @@ impl<'f> Frame<'f> {
             [
                 unsafe {
                     std::slice::from_raw_parts::<u8>(
-                        planes[0].as_ptr() as (*const u8),
+                        planes[0].as_ptr() as *const u8,
                         planes[0].len() * 2,
                     )
                 },
                 unsafe {
                     std::slice::from_raw_parts::<u8>(
-                        planes[1].as_ptr() as (*const u8),
+                        planes[1].as_ptr() as *const u8,
                         planes[1].len() * 2,
                     )
                 },
                 unsafe {
                     std::slice::from_raw_parts::<u8>(
-                        planes[2].as_ptr() as (*const u8),
+                        planes[2].as_ptr() as *const u8,
                         planes[2].len() * 2,
                     )
                 },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,10 +40,10 @@ pub enum ParseError {
     InvalidY4M,
     /// Error parsing int
     Int,
-    /// Error parsing UTF8 
+    /// Error parsing UTF8
     Utf8,
     /// General Parsing Error
-    General
+    General,
 }
 
 impl fmt::Debug for ParseError {
@@ -52,7 +52,7 @@ impl fmt::Debug for ParseError {
             ParseError::InvalidY4M => write!(f, "Error parsing y4m header"),
             ParseError::Int => write!(f, "Error parsing Int"),
             ParseError::Utf8 => write!(f, "Error parsing UTF8"),
-            ParseError::General => write!(f, "General parsing error"), 
+            ParseError::General => write!(f, "General parsing error"),
         }
     }
 }
@@ -205,7 +205,8 @@ impl Colorspace {
 fn get_plane_sizes(width: usize, height: usize, colorspace: Colorspace) -> (usize, usize, usize) {
     let y_plane_size = width * height * colorspace.get_bytes_per_sample();
 
-    let c420_chroma_size = ((width + 1) / 2) * ((height + 1) / 2) * colorspace.get_bytes_per_sample();
+    let c420_chroma_size =
+        ((width + 1) / 2) * ((height + 1) / 2) * colorspace.get_bytes_per_sample();
     let c422_chroma_size = ((width + 1) / 2) * height * colorspace.get_bytes_per_sample();
 
     let c420_sizes = (y_plane_size, c420_chroma_size, c420_chroma_size);


### PR DESCRIPTION
This fixes clippy warnings: "unnecessary parentheses around type" and 
format of the code.