### PR TITLE
Add pixel aspect support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,17 @@ impl Ratio {
     pub fn new(num: usize, den: usize) -> Ratio {
         Ratio { num, den }
     }
+
+    /// Parse a ratio from a byte slice.
+    pub fn parse(value: &[u8]) -> Result<Ratio, Error> {
+        let parts: Vec<_> = value.splitn(2, |&b| b == RATIO_SEP).collect();
+        if parts.len() != 2 {
+            parse_error!(ParseError::General)
+        }
+        let num = parse_bytes(parts[0])?;
+        let den = parse_bytes(parts[1])?;
+        Ok(Ratio::new(num, den))
+    }
 }
 
 impl fmt::Display for Ratio {
@@ -333,15 +344,7 @@ impl<R: Read> Decoder<R> {
             match name {
                 b'W' => width = parse_bytes(value)?,
                 b'H' => height = parse_bytes(value)?,
-                b'F' => {
-                    let parts: Vec<_> = value.splitn(2, |&b| b == RATIO_SEP).collect();
-                    if parts.len() != 2 {
-                        parse_error!(ParseError::General)
-                    }
-                    let num = parse_bytes(parts[0])?;
-                    let den = parse_bytes(parts[1])?;
-                    framerate = Ratio::new(num, den);
-                }
+                b'F' => framerate = Ratio::parse(value)?,
                 b'C' => {
                     colorspace = match value {
                         b"mono" => Some(Colorspace::Cmono),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,6 +538,7 @@ pub struct EncoderBuilder {
     width: usize,
     height: usize,
     framerate: Ratio,
+    pixel_aspect: Ratio,
     colorspace: Colorspace,
 }
 
@@ -548,6 +549,7 @@ impl EncoderBuilder {
             width,
             height,
             framerate,
+            pixel_aspect: Ratio::new(1, 1),
             colorspace: Colorspace::C420,
         }
     }
@@ -555,6 +557,12 @@ impl EncoderBuilder {
     /// Specify file colorspace.
     pub fn with_colorspace(mut self, colorspace: Colorspace) -> Self {
         self.colorspace = colorspace;
+        self
+    }
+
+    /// Specify file pixel aspect.
+    pub fn with_pixel_aspect(mut self, pixel_aspect: Ratio) -> Self {
+        self.pixel_aspect = pixel_aspect;
         self
     }
 
@@ -567,6 +575,9 @@ impl EncoderBuilder {
             "W{} H{} F{}",
             self.width, self.height, self.framerate
         )?;
+        if self.pixel_aspect.num != 1 || self.pixel_aspect.den != 1 {
+            write!(writer, " A{}", self.pixel_aspect)?;
+        }
         write!(writer, " {:?}", self.colorspace)?;
         writer.write_all(&[TERMINATOR])?;
         let (y_len, u_len, v_len) = get_plane_sizes(self.width, self.height, self.colorspace);


### PR DESCRIPTION
This is useful for older DVD-era videos which were usually encoded with non-square pixels.