### PR TITLE
fix compiler warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ impl fmt::Debug for ParseError {
 
 macro_rules! parse_error {
     ($p:expr) => {
-        return Err(Error::ParseError($p));
+        return Err(Error::ParseError($p))
     };
 }
 


### PR DESCRIPTION
Hi. Thanks for this great crate. I am getting the following compiler warning:

```
warning: trailing semicolon in macro used in expression position
   --> src/lib.rs:110:42
    |
110 |         return Err(Error::ParseError($p));
    |                                          ^
...
401 |             parse_error!(ParseError::InvalidY4M)
    |             ------------------------------------ in this macro invocation
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: macro invocations at the end of a block are treated as expressions
    = note: to ignore the value produced by the macro, add a semicolon after the invocation of `parse_error`
    = note: this warning originates in the macro `parse_error` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This warning is fixed by this PR.