### PR TITLE
Remove trailing semicolon from parse_error macro.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ impl fmt::Debug for ParseError {
 macro_rules! parse_error {
     ($p:expr) => {
         return Err(Error::ParseError($p))
-    };
+    }
 }
 
 impl From<io::Error> for Error {


### PR DESCRIPTION
This is for compatibility with future Rust editions.

https://github.com/rust-lang/rust/issues/79813
